### PR TITLE
Allow model object/instance pk to pass to uuslug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ url = 'https://github.com/un33k/django-uuslug'
 author = 'Val Neekman'
 author_email = 'info@neekware.com'
 license = 'BSD'
-install_requires = ['python-slugify>=0.0.4']
+install_requires = ['Django>=1.5.1', 'python-slugify>=0.0.4']
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Web Environment',

--- a/uuslug/__init__.py
+++ b/uuslug/__init__.py
@@ -13,13 +13,22 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, w
     return smart_unicode(pyslugify(text, entities, decimal, hexadecimal, max_length, word_boundary, separator))
 
 
-def uuslug(s, instance, entities=True, decimal=True, hexadecimal=True,
+def uuslug(s, instance, model=None, entities=True, decimal=True, hexadecimal=True,
     slug_field='slug', filter_dict=None, start_no=1, max_length=0, word_boundary=False, separator='-'):
 
     """ This method tries a little harder than django's django.template.defaultfilters.slugify. """
 
     if hasattr(instance, 'objects'):
-        raise Exception("Error: you must pass an instance to uuslug, not a model.")
+        raise Exception("Error: instance must be a model instance or pk, not a model class")
+
+    if model:
+        try:
+            instance = model.objects.get(pk=instance)
+        except model.DoesNotExist:
+            raise Exception("Error: model/instance pk combo does not exist")
+        except:
+            raise Exception("Error: when supplying model, instance \
+                            should be a valid pk for instance of that model")
 
     queryset = instance.__class__.objects.all()
     if filter_dict:

--- a/uuslug/tests.py
+++ b/uuslug/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 # http://pypi.python.org/pypi/django-tools/
 #from django_tools.unittest_utils.print_sql import PrintQueries
 
-from uuslug import slugify
+from uuslug import slugify, uuslug
 from uuslug.models import (CoolSlug, AnotherSlug, TruncatedSlug,
                            SmartTruncatedSlug, SmartTruncatedExactWordBoundrySlug,
                            CoolSlugDifferentSeparator, TruncatedSlugDifferentSeparator)
@@ -187,4 +187,12 @@ class SlugUniqueDifferentSeparatorTestCase(TestCase):
         self.assertEquals(obj.slug, "jaja_lol_mememe_3") # 17 is max_length
 
 
+class SlugFromModelTestCase(TestCase):
+    """Tests that a slug can be created from a model/instance pk combo""" 
+    
+    def testManager(self):
+        name = "Foo Bar"
+        obj = CoolSlug.objects.create(name=name)
+        slug = uuslug(name, instance=obj.pk, model=CoolSlug)
 
+        self.assertEquals(slug, 'foo-bar-1')


### PR DESCRIPTION
It is sometimes useful to allow model class/instance pk to be passed to the uuslug method rather than just an instance. I came across this issue during a South datamigration where the model instances don't conform to the "objects" check currently in uuslug, so passing the orm frozen model and pk was the solution to get a workable instance. Alternatively, could use a different check to differentiate between models and instances, but wasn't sure of another good way to do that. So I created this instead.
