### PR TITLE
Fix: False alarm on model/instance check

### DIFF
--- a/uuslug/__init__.py
+++ b/uuslug/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = '1.0.0'
 
+from django.db.models.base import ModelBase
 from django.utils.encoding import smart_unicode
 from slugify import slugify as pyslugify
 
@@ -9,7 +10,7 @@ __all__ = ['slugify', 'uuslug']
 
 def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, word_boundary=False, separator='-'):
     """ Make a slug from a given text """
-    
+
     return smart_unicode(pyslugify(text, entities, decimal, hexadecimal, max_length, word_boundary, separator))
 
 
@@ -18,7 +19,7 @@ def uuslug(s, instance, entities=True, decimal=True, hexadecimal=True,
 
     """ This method tries a little harder than django's django.template.defaultfilters.slugify. """
 
-    if hasattr(instance, 'objects'):
+    if isinstance(instance, ModelBase):
         raise Exception("Error: you must pass an instance to uuslug, not a model.")
 
     queryset = instance.__class__.objects.all()

--- a/uuslug/tests.py
+++ b/uuslug/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 # http://pypi.python.org/pypi/django-tools/
 #from django_tools.unittest_utils.print_sql import PrintQueries
 
-from uuslug import slugify
+from uuslug import slugify, uuslug
 from uuslug.models import (CoolSlug, AnotherSlug, TruncatedSlug,
                            SmartTruncatedSlug, SmartTruncatedExactWordBoundrySlug,
                            CoolSlugDifferentSeparator, TruncatedSlugDifferentSeparator)
@@ -18,11 +18,11 @@ class SlugUnicodeTestCase(TestCase):
         txt = "This is a test ---"
         r = slugify(txt)
         self.assertEquals(r, "this-is-a-test")
-        
+
         txt = "This -- is a ## test ---"
         r = slugify(txt)
         self.assertEquals(r, "this-is-a-test")
-        
+
         txt = 'C\'est déjà l\'été.'
         r = slugify(txt)
         self.assertEquals(r, "cest-deja-lete")
@@ -73,7 +73,7 @@ class SlugUnicodeTestCase(TestCase):
 
 class SlugUniqueTestCase(TestCase):
     """Tests for Slug - Unique"""
-    
+
     def test_manager(self):
         name = "john"
 
@@ -187,4 +187,8 @@ class SlugUniqueDifferentSeparatorTestCase(TestCase):
         self.assertEquals(obj.slug, "jaja_lol_mememe_3") # 17 is max_length
 
 
+class ExeptionTestCase(TestCase):
+
+    def test_uuslug_checks_for_model_instance(self):
+        self.assertRaises(Exception, uuslug, 'test_slug', CoolSlug)
 


### PR DESCRIPTION
Unfotunately there is no guarantee that a model instance will not have an `objects` attribute. When using `MoneyField` from django-money your instances will have an `objects` attribute and uuslug will raise an exception.