### PR TITLE
Enabled uuslug to be django parler friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,29 +217,31 @@ Django Parler
 ====================
 For translatable slugs using Django Parler, a language code needs to be passed to the uuslug function. Here is an example model overriding the save method:
 
-	from django.utils.translation import ugettext_lazy as _
+   ```python
+   
+    from django.utils.translation import ugettext_lazy as _
     from parler.models import TranslatableModel, TranslatedFields
-    
+
     from uuslug import uuslug
-    
+
 
     class MyTranslatableModel(TranslatableModel):
         ...
         
         translations = TranslatedFields(
-     		name = models.CharField(_('Name'), max_length=100),
-			slug = models.SlugField(_('slug'), max_length=255, blank=True, allow_unicode=True),
-			meta = {'unique_together': (('language_code', 'slug'),)}
-		)
+            name = models.CharField(_('Name'), max_length=100),
+            slug = models.SlugField(_('slug'), max_length=255, blank=True, allow_unicode=True),
+            meta = {'unique_together': (('language_code', 'slug'),)}
+        )
 
         def save(self, *args, **kwargs):
-	    	super(MyTranslatableModel, self).save(*args, **kwargs)
-		    for lang in self.get_available_languages():
-			    self.set_current_language(lang)
-			    if not self.slug and self.name:
-				    self.slug = uuslug(self.name, instance=self, language_code=lang)
-    		self.save_translations()
-
+            super(MyTranslatableModel, self).save(*args, **kwargs)
+            for lang in self.get_available_languages():
+                self.set_current_language(lang)
+                if not self.slug and self.name:
+                    self.slug = uuslug(self.name, instance=self, language_code=lang)
+            self.save_translations()
+   ```
 
 License
 ====================

--- a/README.md
+++ b/README.md
@@ -213,6 +213,27 @@ To run the tests against the current environment:
 
     python manage.py test
 
+Django Parler
+====================
+For translatable slugs using Django Parler, a language code needs to be passed to the uuslug function. Here is an example overriding the save function:
+
+    from parler.models import TranslatableModel, TranslatedFields
+
+    class MyTranslatableModel(TranslatableModel):
+        ...
+        translations = TranslatedFields(
+		    slug = models.SlugField(_('slug'), max_length=255, blank=True, allow_unicode=True),
+		    meta = {'unique_together': (('language_code', 'slug'),)}
+	    )
+
+        def save(self, *args, **kwargs):
+	    	super(MyTranslatableModel, self).save(*args, **kwargs)
+		    for lang in self.get_available_languages():
+			    self.set_current_language(lang)
+			    if not self.slug and self.name:
+				    self.slug = uuslug(self.name, instance=self, language_code=lang)
+    		self.save_translations()
+
 
 License
 ====================

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ How to use
 
     txt = 'C\'est déjà l\'été.'
     r = slugify(txt)
-    self.assertEqual(r, "cest-deja-lete")
+    self.assertEqual(r, "c-est-deja-l-ete")
 
     txt = 'Nín hǎo. Wǒ shì zhōng guó rén'
     r = slugify(txt)

--- a/README.md
+++ b/README.md
@@ -215,16 +215,22 @@ To run the tests against the current environment:
 
 Django Parler
 ====================
-For translatable slugs using Django Parler, a language code needs to be passed to the uuslug function. Here is an example overriding the save function:
+For translatable slugs using Django Parler, a language code needs to be passed to the uuslug function. Here is an example model overriding the save method:
 
+	from django.utils.translation import ugettext_lazy as _
     from parler.models import TranslatableModel, TranslatedFields
+    
+    from uuslug import uuslug
+    
 
     class MyTranslatableModel(TranslatableModel):
         ...
+        
         translations = TranslatedFields(
-		    slug = models.SlugField(_('slug'), max_length=255, blank=True, allow_unicode=True),
-		    meta = {'unique_together': (('language_code', 'slug'),)}
-	    )
+     		name = models.CharField(_('Name'), max_length=100),
+			slug = models.SlugField(_('slug'), max_length=255, blank=True, allow_unicode=True),
+			meta = {'unique_together': (('language_code', 'slug'),)}
+		)
 
         def save(self, *args, **kwargs):
 	    	super(MyTranslatableModel, self).save(*args, **kwargs)

--- a/uuslug/tests/tests.py
+++ b/uuslug/tests/tests.py
@@ -31,7 +31,7 @@ class SlugUnicodeTestCase(TestCase):
 
         txt = 'C\'est déjà l\'été.'
         r = slugify(txt)
-        self.assertEqual(r, "cest-deja-lete")
+        self.assertEqual(r, "c-est-deja-l-ete")
 
         txt = 'Nín hǎo. Wǒ shì zhōng guó rén'
         r = slugify(txt)

--- a/uuslug/uuslug.py
+++ b/uuslug/uuslug.py
@@ -41,15 +41,13 @@ def uuslug(s, instance, entities=True, decimal=True, hexadecimal=True,
         try:
             meta = instance._parler_meta._get_extension_by_field(slug_field)
             slug_field_max_length = instance._get_translated_model(
-                    language_code, meta=meta
-                )._meta.get_field(slug_field).max_length
-            
+                language_code, meta=meta
+            )._meta.get_field(slug_field).max_length
         except AttributeError:
             raise Exception("Error: This instance is not from a Django Parler TranslatableModel. Remove language_code parameter and try again.")
 
     else:
         slug_field_max_length = instance._meta.get_field(slug_field).max_length
-
 
     if not max_length or max_length > slug_field_max_length:
         max_length = slug_field_max_length

--- a/uuslug/uuslug.py
+++ b/uuslug/uuslug.py
@@ -21,7 +21,8 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0,
 
 def uuslug(s, instance, entities=True, decimal=True, hexadecimal=True,
            slug_field='slug', filter_dict=None, start_no=1, max_length=0,
-           word_boundary=False, separator='-', save_order=False, stopwords=()):
+           word_boundary=False, separator='-', save_order=False, stopwords=(),
+           language_code=None):
 
     """ This method tries a little harder than django's django.template.defaultfilters.slugify. """
 
@@ -35,7 +36,21 @@ def uuslug(s, instance, entities=True, decimal=True, hexadecimal=True,
         queryset = queryset.exclude(pk=instance.pk)
 
     # The slug max_length cannot be bigger than the max length of the field
-    slug_field_max_length = instance._meta.get_field(slug_field).max_length
+    if language_code:
+        # To support django parler there's a little more work needed to get the field.
+        try:
+            meta = instance._parler_meta._get_extension_by_field(slug_field)
+            slug_field_max_length = instance._get_translated_model(
+                    language_code, meta=meta
+                )._meta.get_field(slug_field).max_length
+            
+        except AttributeError:
+            raise Exception("Error: This instance is not from a Django Parler TranslatableModel. Remove language_code parameter and try again.")
+
+    else:
+        slug_field_max_length = instance._meta.get_field(slug_field).max_length
+
+
     if not max_length or max_length > slug_field_max_length:
         max_length = slug_field_max_length
 
@@ -45,10 +60,20 @@ def uuslug(s, instance, entities=True, decimal=True, hexadecimal=True,
 
     new_slug = slug
     counter = start_no
-    while queryset.filter(**{slug_field: new_slug}).exists():
+
+    def _new_slug(slug, separator, counter, max_length):
         if len(slug) + len(separator) + len(str(counter)) > max_length:
             slug = slug[:max_length - len(slug) - len(separator) - len(str(counter))]
-        new_slug = "{}{}{}".format(slug, separator, counter)
-        counter += 1
+        return "{}{}{}".format(slug, separator, counter)
+
+    if language_code:
+        # need to use translated queryset
+        while queryset.translated(**{slug_field: new_slug}):
+            new_slug = _new_slug(slug=slug, separator=separator, counter=counter, max_length=max_length)
+            counter += 1
+    else:
+        while queryset.filter(**{slug_field: new_slug}):
+            new_slug = _new_slug(slug=slug, separator=separator, counter=counter, max_length=max_length)
+            counter += 1
 
     return new_slug


### PR DESCRIPTION
This enables translatable slugs using Django parler to work with the uuslug function.

Django parler does not store the translated fields in the same database table, so using Django's meta api to call the get_field() fails. By passing a language code as an argument, with a couple of extra steps the same result can be achieved.

No extra dependencies are required, the user simply has to pass the optional language_code argument and the function will do the rest.

An example model has been added to the README to demonstrate usage.
