### PR TITLE
Update Django and Python versions and use flake8 in Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Dev env
+.env/
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,42 @@
 sudo: false
 language: python
+dist: xenial
 
 python:
-  - "3.5"
-  - "3.4"
-  - "3.3"
+  - "3.7"
+  - "3.6"
   - "2.7"
   - pypy
+  - pypy3
 
 env:
-  - DJANGO="django==1.10.6"
-  - DJANGO="django==1.9.12"
-  - DJANGO="django==1.8.17"
+  # Django 2.2.x
+  - DJANGO="django>=2.2,<2.3"
+  # Django 2.1.x
+  - DJANGO="django>=2.1,<2.2"
+  # Django 1.11.x
+  - DJANGO="django>=1.11,<1.12"
 
 install:
   - pip install $DJANGO
   - pip install -r requirements.txt
   - pip install -e .
-  - pip install pep8
-  - pip install https://github.com/un33k/pyflakes/tarball/master
-  - pip install coveralls
+  - pip install flake8 coverage coveralls
 
 before_script:
-  - "pep8 --exclude=migrations --ignore=E501,E225,E128 ."
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pyflakes -x W uuslug; fi
+  - "flake8 uuslug"
 
 matrix:
   exclude:
-   - python: "3.3"
-     env: DJANGO="django==1.10.6"
-   - python: "3.3"
-     env: DJANGO="django==1.9.12"
+   - python: "2.7"
+     env: DJANGO="django>=2.2,<2.3"
+   - python: "2.7"
+     env: DJANGO="django>=2.1,<2.2"
+   # pypy is the Python 2.7
+   - python: "pypy"
+     env: DJANGO="django>=2.2,<2.3"
+   - python: "pypy"
+     env: DJANGO="django>=2.1,<2.2"
 
 script: coverage run --source=uuslug manage.py test
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = migrations
+ignore = E501,E225,E128

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,17 @@ license = 'BSD'
 install_requires = ['python-slugify>=1.2.0']
 classifiers = [
     'Development Status :: 5 - Production/Stable',
+    'Framework :: Django :: 1.11',
+    'Framework :: Django :: 2.1',
+    'Framework :: Django :: 2.2',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Operating System :: POSIX',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 
 

--- a/uuslug/__init__.py
+++ b/uuslug/__init__.py
@@ -1,4 +1,4 @@
-from .uuslug import *
+from .uuslug import *  # noqa
 
 __author__ = 'Val Neekman @ Neekware Inc. [@vneekman]'
 __description__ = 'A Python slugify application that also handles Unicode'

--- a/uuslug/apps.py
+++ b/uuslug/apps.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from django.apps import AppConfig as DjangoAppConfig
 from django.utils.translation import ugettext_lazy as _
 

--- a/uuslug/tests/tests.py
+++ b/uuslug/tests/tests.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 
 from uuslug import slugify, uuslug
 from uuslug.models import (CoolSlug, AnotherSlug, TruncatedSlug,
-                           SmartTruncatedSlug, SmartTruncatedExactWordBoundrySlug,
+                           SmartTruncatedExactWordBoundrySlug,
                            CoolSlugDifferentSeparator, TruncatedSlugDifferentSeparator,
                            AutoTruncatedSlug)
 


### PR DESCRIPTION
* Add Python 3.6 and 3.7 and remove old versions 3.3, 3.4 and 3.5.
* Add pypy3.
* Add Django 1.11.x, 2.1.x and 2.2.x and remove old versions 1.8, 1.9
  and 1.10.
* Replace pep8 with flake8 and fix errors detected by flake8
  accordingly.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>